### PR TITLE
chore: bump deepgram-sdk floor to >=7.7.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ python-dotenv==1.0.1
 toml==0.10.2
 werkzeug==3.1.4
 
-deepgram-sdk>=7.6.0
+deepgram-sdk>=7.7.0


### PR DESCRIPTION
Bumps the `deepgram-sdk` floor from `>=7.6.0` to `>=7.7.0`.

7.7.0 masks the `Authorization` header in `ApiError` string output; 7.6.0 emitted the raw `Token <api-key>`. Raising the floor guarantees SDK-side credential redaction. Consistency bump across the Python starters.